### PR TITLE
Add support for getCollections

### DIFF
--- a/src/firebase/firestore/document-reference/index.js
+++ b/src/firebase/firestore/document-reference/index.js
@@ -28,6 +28,17 @@ export default class DocumentReference {
     return this._getCollectionReference(id);
   }
 
+  getCollections() {
+    if (this._data.__collection__ === undefined) {
+      return Promise.resolve([]);
+    }
+
+    const collectionIds = Object.keys(this._data.__collection__);
+    const collectionReferences = collectionIds.map(id => this._getCollectionReference(id));
+
+    return Promise.resolve(collectionReferences);
+  }
+
   delete() {
     if (this._data) {
       this._data.__isDirty__ = false;

--- a/src/unit-test.js
+++ b/src/unit-test.js
@@ -1036,6 +1036,39 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
       });
     });
 
+    QUnit.module('function: getCollections', () => {
+      QUnit.test('should return all the subcollection references of the document', async (assert) => {
+        assert.expect(6);
+
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = await db.doc('users/user_a').getCollections();
+
+        // Assert
+        assert.ok(result instanceof Array);
+        assert.equal(result.length, 2);
+        assert.ok(result[0] instanceof CollectionReference);
+        assert.equal(result[0].id, 'friends');
+        assert.ok(result[1] instanceof CollectionReference);
+        assert.equal(result[1].id, 'enemies');
+      });
+
+      QUnit.test('should not throw when document doesn\'t exist', async (assert) => {
+        assert.expect(1);
+
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = await db.doc('users/user_unknown').getCollections();
+
+        // Assert
+        assert.deepEqual(result, []);
+      });
+    });
+
     QUnit.module('function: doc', () => {
       QUnit.test('should return the document reference using a path', (assert) => {
         assert.expect(2);

--- a/src/utils/test-helpers/fixture-data.js
+++ b/src/utils/test-helpers/fixture-data.js
@@ -22,6 +22,13 @@ export default function fixtureData() {
                   },
                 },
               },
+              enemies: {
+                __doc__: {
+                  user_c: {
+                    reference: '__ref__:users/user_c',
+                  },
+                },
+              },
             },
           },
           user_b: {


### PR DESCRIPTION
`getCollections` is vaguely documented here:
https://firebase.google.com/docs/firestore/query-data/get-data