### PR TITLE
Fix regression on query ordering

### DIFF
--- a/src/unit-test.js
+++ b/src/unit-test.js
@@ -1409,11 +1409,11 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
         const db = mockFirebase.firestore();
 
         // Act
-        const snapshot = await db.collection('users').where('age', '==', 15).get();
+        const snapshot = await db.collection('users').where('age', '==', 10).limit(1).get();
 
         // Assert
         assert.equal(snapshot.docs.length, 1);
-        assert.equal(snapshot.docs[0].id, 'user_a');
+        assert.equal(snapshot.docs[0].id, 'user_b');
       });
     });
   });


### PR DESCRIPTION
This fixes a regression introduced in #46. The issue concerns the
ordering of the queries.

e.g.

`limit` always gets fired first before `where`. This could lead to
incorrect data being returned.