### PR TITLE
Fixed orderBy on empty collection

### DIFF
--- a/src/firebase/firestore/query/index.js
+++ b/src/firebase/firestore/query/index.js
@@ -17,11 +17,11 @@ export default class Query {
   }
 
   _querySnapshot() {
-    const data = Object.assign({}, this._data);
+    const data = Object.assign({ __doc__: {} }, this._data);
 
     this._operations.forEach((operation) => {
       if (operation.type === 'orderBy') {
-        data.__doc__ = orderBy(data.__doc__ || {}, operation.param.key, operation.param.sorting);
+        data.__doc__ = orderBy(data.__doc__, operation.param.key, operation.param.sorting);
       }
 
       if (operation.type === 'startAt') {

--- a/src/firebase/firestore/query/index.js
+++ b/src/firebase/firestore/query/index.js
@@ -21,7 +21,7 @@ export default class Query {
 
     this._operations.forEach((operation) => {
       if (operation.type === 'orderBy') {
-        data.__doc__ = orderBy(data.__doc__, operation.param.key, operation.param.sorting);
+        data.__doc__ = orderBy(data.__doc__ || {}, operation.param.key, operation.param.sorting);
       }
 
       if (operation.type === 'startAt') {

--- a/src/unit-test.js
+++ b/src/unit-test.js
@@ -1336,6 +1336,19 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
         assert.equal(snapshot.docs[1].id, 'user_a');
         assert.equal(snapshot.docs[2].id, 'user_c');
       });
+
+      QUnit.test('should return empty array with empty collection', async (assert) => {
+        assert.expect(1);
+
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const snapshot = await db.collection('unknown').orderBy('age').get();
+
+        // Assert
+        assert.equal(snapshot.docs.length, 0);
+      });
     });
 
     QUnit.module('function: startAfter', () => {


### PR DESCRIPTION
Hi, i fixed an error when i use orderBy on empty collection.

**Node version**: 8.16.0

## Code to reproduce
```javascript
const MockFirebase = require('mock-cloud-firestore');
const firebase = new MockFirebase();

firebase
  .firestore()
  .collection('/unknown')
  .orderBy('createdAt')
  .get();
```
## Error
```
/myProject/node_modules/mock-cloud-firestore/lib/mock-cloud-firestore.js:843
    ids = Object.keys(data).slice().sort((a, b) => {
                 ^

TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at orderBy (/myProject/node_modules/mock-cloud-firestore/lib/mock-cloud-firestore.js:843:18)
    at _operations.forEach.operation (/myProject/node_modules/mock-cloud-firestore/lib/mock-cloud-firestore.js:942:24)
    at Array.forEach (<anonymous>)
    at Query._querySnapshot (/myProject/node_modules/mock-cloud-firestore/lib/mock-cloud-firestore.js:940:22)
    at Query.get (/myProject/node_modules/mock-cloud-firestore/lib/mock-cloud-firestore.js:1014:47)
    at Object.<anonymous> (/myProject/debug.js:21:4)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
```
