### PR TITLE
Feat: adding naive transaction implementation

### DIFF
--- a/src/firebase/firestore/index.js
+++ b/src/firebase/firestore/index.js
@@ -3,6 +3,7 @@ import CollectionReference from './collection-reference';
 import WriteBatch from './write-batch';
 import getOrSetDataNode from '../../utils/get-or-set-data-node';
 import validateReference from '../../utils/reference';
+import TransactionWriteBatch from './transaction';
 
 export default class Firestore {
   constructor(data, options) {
@@ -33,6 +34,10 @@ export default class Firestore {
 
   batch() {
     return new WriteBatch();
+  }
+
+  runTransaction(executor) {
+    return executor(new TransactionWriteBatch());
   }
 
   collection(id) {

--- a/src/firebase/firestore/transaction/index.js
+++ b/src/firebase/firestore/transaction/index.js
@@ -14,8 +14,4 @@ export default class TransactionWriteBatch {
   get(ref) {
     return ref.get();
   }
-
-  getAll(...refs) {
-    return Promise.all(refs.map(r => r.get()));
-  }
 }

--- a/src/firebase/firestore/transaction/index.js
+++ b/src/firebase/firestore/transaction/index.js
@@ -1,0 +1,21 @@
+export default class TransactionWriteBatch {
+  delete(ref) {
+    return ref.delete();
+  }
+
+  set(ref, data, option = {}) {
+    return ref.set(data, option);
+  }
+
+  update(ref, data) {
+    return ref.update(data);
+  }
+
+  get(ref) {
+    return ref.get();
+  }
+
+  getAll(...refs) {
+    return Promise.all(refs.map(r => r.get()));
+  }
+}

--- a/src/unit-test.js
+++ b/src/unit-test.js
@@ -1584,31 +1584,5 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
       const user = await db.collection('users').doc('user_a').get();
       assert.deepEqual(user.data(), undefined);
     });
-
-    QUnit.test('transaction.getAll: should be able to getAll references', async (assert) => {
-      assert.expect(3);
-
-      // Arrange
-      const db = mockFirebase.firestore();
-      const ref = db.collection('users').doc('user_a');
-      const ref2 = db.collection('users').doc('user_b');
-      const ref3 = db.collection('users').doc('user_c');
-
-
-      await ref.set({ username: 'new_user' });
-      await ref2.set({ username: 'new_user2' });
-      await ref3.set({ username: 'new_user3' });
-
-      // Act
-      let users = null;
-      await db.runTransaction(async (tran) => {
-        users = await tran.getAll(ref, ref2, ref3);
-      });
-
-      // Assert
-      assert.deepEqual(users[0].data(), { username: 'new_user' });
-      assert.deepEqual(users[1].data(), { username: 'new_user2' });
-      assert.deepEqual(users[2].data(), { username: 'new_user3' });
-    });
   });
 });

--- a/src/unit-test.js
+++ b/src/unit-test.js
@@ -1503,4 +1503,112 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
       });
     });
   });
+
+  QUnit.module('Transactions', () => {
+    QUnit.test('transaction.get: should be able to get references', async (assert) => {
+      assert.expect(1);
+
+      // Arrange
+      const db = mockFirebase.firestore();
+      const ref = db.collection('users').doc('user_a');
+
+
+      await ref.set({ username: 'new_user' });
+
+      // Act
+      let user = null;
+      await db.runTransaction(async (tran) => {
+        user = await tran.get(ref);
+      });
+
+      // Assert
+      assert.deepEqual(user.data(), { username: 'new_user' });
+    });
+
+    QUnit.test('transaction.set: should be able to set references', async (assert) => {
+      assert.expect(1);
+
+      // Arrange
+      const db = mockFirebase.firestore();
+      const ref = db.collection('users').doc('user_a');
+
+
+      await ref.set({ username: 'new_user' });
+
+      // Act
+      await db.runTransaction(async (tran) => {
+        await tran.set(ref, { username: 'new_user2' });
+      });
+
+      // Assert
+      const user = await db.collection('users').doc('user_a').get();
+      assert.deepEqual(user.data(), { username: 'new_user2' });
+    });
+
+    QUnit.test('transaction.update: should be able to update references', async (assert) => {
+      assert.expect(1);
+
+      // Arrange
+      const db = mockFirebase.firestore();
+      const ref = db.collection('users').doc('user_a');
+
+
+      await ref.set({ username: 'new_user' });
+
+      // Act
+      await db.runTransaction(async (tran) => {
+        await tran.update(ref, { username: 'new_user2' });
+      });
+
+      // Assert
+      const user = await db.collection('users').doc('user_a').get();
+      assert.deepEqual(user.data(), { username: 'new_user2' });
+    });
+
+    QUnit.test('transaction.delete: should be able to delete references', async (assert) => {
+      assert.expect(1);
+
+      // Arrange
+      const db = mockFirebase.firestore();
+      const ref = db.collection('users').doc('user_a');
+
+
+      await ref.set({ username: 'new_user' });
+
+      // Act
+      await db.runTransaction(async (tran) => {
+        await tran.delete(ref);
+      });
+
+      // Assert
+      const user = await db.collection('users').doc('user_a').get();
+      assert.deepEqual(user.data(), undefined);
+    });
+
+    QUnit.test('transaction.getAll: should be able to getAll references', async (assert) => {
+      assert.expect(3);
+
+      // Arrange
+      const db = mockFirebase.firestore();
+      const ref = db.collection('users').doc('user_a');
+      const ref2 = db.collection('users').doc('user_b');
+      const ref3 = db.collection('users').doc('user_c');
+
+
+      await ref.set({ username: 'new_user' });
+      await ref2.set({ username: 'new_user2' });
+      await ref3.set({ username: 'new_user3' });
+
+      // Act
+      let users = null;
+      await db.runTransaction(async (tran) => {
+        users = await tran.getAll(ref, ref2, ref3);
+      });
+
+      // Assert
+      assert.deepEqual(users[0].data(), { username: 'new_user' });
+      assert.deepEqual(users[1].data(), { username: 'new_user2' });
+      assert.deepEqual(users[2].data(), { username: 'new_user3' });
+    });
+  });
 });


### PR DESCRIPTION
Closes #80 

As discussed in the issue, I added a naive implementation of transactions. It doesn't do any check (throwing if you try to call get after calling a set/update/delete) but is a good start :)