### PR TITLE
Add support for 'array-contains-any' and 'in' query operators

### DIFF
--- a/src/utils/query/index.js
+++ b/src/utils/query/index.js
@@ -129,6 +129,10 @@ export function where(data = {}, key, operator, value) {
       return pathValue >= value;
     } if (operator === 'array-contains') {
       return pathValue.find(item => item === value);
+    } if (operator === 'array-contains-any') {
+      return pathValue.find(item => value.includes(item));
+    } if (operator === 'in') {
+      return value.includes(pathValue);
     }
 
     return pathValue > value;

--- a/src/utils/query/unit-test.js
+++ b/src/utils/query/unit-test.js
@@ -445,6 +445,48 @@ QUnit.module('Unit | Util | query', () => {
         user_c: { books: [10] },
       });
     });
+
+    QUnit.test('should return records matching the array-contains-any filter', (assert) => {
+      assert.expect(1);
+
+      // Arrange
+      const records = {
+        user_a: { books: [10] },
+        user_b: { books: [15] },
+        user_c: { books: [10] },
+        user_d: { books: [20] },
+      };
+
+      // Act
+      const result = where(records, 'books', 'array-contains-any', [10, 20]);
+
+      // Assert
+      assert.deepEqual(result, {
+        user_a: { books: [10] },
+        user_c: { books: [10] },
+        user_d: { books: [20] },
+      });
+    });
+
+    QUnit.test('should return records matching the in filter', (assert) => {
+      assert.expect(1);
+
+      // Arrange
+      const records = {
+        user_a: { name: 'User A' },
+        user_b: { name: 'User B' },
+        user_c: { name: 'User C' },
+      };
+
+      // Act
+      const result = where(records, 'name', 'in', ['User A', 'User C']);
+
+      // Assert
+      assert.deepEqual(result, {
+        user_a: { name: 'User A' },
+        user_c: { name: 'User C' },
+      });
+    });
   });
 
   QUnit.module('function: querySnapshot', () => {


### PR DESCRIPTION
Add 2 new query operators that have recently been added to the javascript SDK:

- `array-contains-any`
- `in`

The operators were added in:

- `firebase@7.3.0` https://firebase.google.com/support/release-notes/js#version_730_-_november_7_2019
- `firebase-admin@8.8.0` https://firebase.google.com/support/release-notes/admin/node#version_880_-_19_november_2019

More information: https://cloud.google.com/firestore/docs/query-data/queries#in_and_array-contains-any