### PR TITLE
Fix undefined pathValue for contains operators

### DIFF
--- a/src/utils/query/index.js
+++ b/src/utils/query/index.js
@@ -128,9 +128,9 @@ export function where(data = {}, key, operator, value) {
     } if (operator === '>=') {
       return pathValue >= value;
     } if (operator === 'array-contains') {
-      return pathValue.find(item => item === value);
+      return (pathValue || []).find(item => item === value);
     } if (operator === 'array-contains-any') {
-      return pathValue.find(item => value.includes(item));
+      return (pathValue || []).find(item => value.includes(item));
     } if (operator === 'in') {
       return value.includes(pathValue);
     }

--- a/src/utils/query/unit-test.js
+++ b/src/utils/query/unit-test.js
@@ -434,6 +434,7 @@ QUnit.module('Unit | Util | query', () => {
         user_a: { books: [10] },
         user_b: { books: [15] },
         user_c: { books: [10] },
+        user_d: {},
       };
 
       // Act
@@ -443,6 +444,49 @@ QUnit.module('Unit | Util | query', () => {
       assert.deepEqual(result, {
         user_a: { books: [10] },
         user_c: { books: [10] },
+      });
+    });
+
+    QUnit.test('should return records matching the array-contains-any filter', (assert) => {
+      assert.expect(1);
+
+      // Arrange
+      const records = {
+        user_a: { books: [10] },
+        user_b: { books: [15] },
+        user_c: { books: [10] },
+        user_d: { books: [20] },
+        user_e: {},
+      };
+
+      // Act
+      const result = where(records, 'books', 'array-contains-any', [10, 20]);
+
+      // Assert
+      assert.deepEqual(result, {
+        user_a: { books: [10] },
+        user_c: { books: [10] },
+        user_d: { books: [20] },
+      });
+    });
+
+    QUnit.test('should return records matching the in filter', (assert) => {
+      assert.expect(1);
+
+      // Arrange
+      const records = {
+        user_a: { name: 'User A' },
+        user_b: { name: 'User B' },
+        user_c: { name: 'User C' },
+      };
+
+      // Act
+      const result = where(records, 'name', 'in', ['User A', 'User C']);
+
+      // Assert
+      assert.deepEqual(result, {
+        user_a: { name: 'User A' },
+        user_c: { name: 'User C' },
       });
     });
 


### PR DESCRIPTION
The mock library currently throws on `array-contains` and `array-contains-any` queries when the `pathValue` does not exist. (empty array `[]` works fine) Added a fix so it doesn't crash on non-existing pathValues for these operators, in accordance with real firestore behaviour.