### PR TITLE
Add support for array property containing DocumentReferences

### DIFF
--- a/src/utils/parse-value/index.js
+++ b/src/utils/parse-value/index.js
@@ -3,12 +3,20 @@
 import { buildPathFromReference } from '../path';
 import DocumentReference from '../../firebase/firestore/document-reference';
 
-function isObject(value) {
+export function isObject(value) {
   return Object.prototype.toString.call(value) === '[object Object]';
 }
 
 function isFieldValue(value) {
   return isObject(value) && Object.prototype.hasOwnProperty.call(value, '_methodName');
+}
+
+function isArrayOfDocumentReferences(array) {
+  return (
+    Array.isArray(array)
+    && array.length > 0
+    && array.map(v => v instanceof DocumentReference).filter(v => !v).length === 0
+  );
 }
 
 function validateValue(value, option) {
@@ -148,6 +156,10 @@ export default function parseValue(newValue, oldValue, option) {
 
   if (isObject(newValue)) {
     return processObject(newValue, oldValue, option);
+  }
+
+  if (isArrayOfDocumentReferences(newValue)) {
+    return newValue.map(v => buildPathFromReference(v));
   }
 
   return newValue;

--- a/src/utils/parse-value/unit-test.js
+++ b/src/utils/parse-value/unit-test.js
@@ -148,6 +148,21 @@ QUnit.module('Unit | Util | parse-value', () => {
       assert.deepEqual(result, ['foo']);
     });
 
+    QUnit.test('should return array of paths when parsing an array of DocumentReferences', (assert) => {
+      assert.expect(1);
+
+      // Arrange
+      const mockFirebase = new MockFirebase(fixtureData());
+      const newValue = [mockFirebase.firestore().doc('users/user_a')];
+      const oldValue = undefined;
+
+      // Act
+      const result = parseValue(newValue, oldValue, { type: 'set:merge-false' });
+
+      // Assert
+      assert.deepEqual(result, ['__ref__:users/user_a']);
+    });
+
     QUnit.test('should return path when parsing a DocumentReference', (assert) => {
       assert.expect(1);
 


### PR DESCRIPTION
So let's say we have a user document which has a property of type Array which holds multiple DocumentReferences:

```
// User
{
  name: 'Fubar',
  pets: [
    '/pets/cat',
  ]
}
```